### PR TITLE
Fix stuck cover on failed art fetch + keep root for web UI

### DIFF
--- a/index.js
+++ b/index.js
@@ -409,10 +409,6 @@ async function checkCover(_entities) {
 
   // Same cover, skip
   if (url === currentCover) return;
-  
-  currentCover = url;
-  currentEntity = activeEntity;
-  syncWebState();
 
   try {
     // Fetch album art
@@ -425,6 +421,12 @@ async function checkCover(_entities) {
 
     // Get pixels and transition
     const newPixels = await getPixelsFromBuffer(imageBuffer);
+
+    // Fetch + decode succeeded — commit state now so a failed fetch can't
+    // freeze the old cover on the matrix or block retries for the same URL.
+    currentCover = url;
+    currentEntity = activeEntity;
+    syncWebState();
 
     if (getMatrix()) {
       stopOverlay();

--- a/lib/matrix.js
+++ b/lib/matrix.js
@@ -22,6 +22,10 @@ export function initMatrix(brightness = 85) {
   const runtimeOptions = {
     ...LedMatrix.defaultRuntimeOptions(),
     gpioSlowdown: 4,
+    // Stay root after matrix init so the web server can read web/ and write
+    // settings; rpi-led-matrix otherwise drops to user daemon, which cannot
+    // traverse the 0700 home dir (HTTP 500 on web UI, EACCES on save).
+    dropPrivileges: -1,
   };
 
   try {


### PR DESCRIPTION
Two fixes found while debugging the deployed Pi.

## 1. Old cover stays on screen when album-art fetch fails (`index.js`)
`checkCover()` set `currentCover = url` **before** fetching the art. When HA's `media_player_proxy` returned a non-200 (observed `500` in the logs), the matrix never transitioned — so the previous cover stayed on screen. Worse, because `currentCover` was already updated, the `if (url === currentCover) return` guard skipped that URL forever, so it never retried.

**Fix:** commit `currentCover`/`currentEntity`/`syncWebState()` only **after** the fetch + decode succeed. Failures now leave state untouched and retry on the next update.

## 2. Web UI returns HTTP 500 / settings fail to save (`lib/matrix.js`)
`rpi-led-matrix` drops privileges to user `daemon` after initializing the matrix. On Raspberry Pi OS Bookworm the home dir is mode `0700`, so `daemon` can't traverse it to read `web/index.html` (500 on the web UI) or write the settings file (EACCES log spam).

**Fix:** `dropPrivileges: -1` keeps the process as root after init.

Both verified live on the deployed Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)